### PR TITLE
Fix particle id guessing when loading data

### DIFF
--- a/ctaplot/gammaboard/gammaboard.py
+++ b/ctaplot/gammaboard/gammaboard.py
@@ -114,7 +114,7 @@ def guess_particle_type_from_file(file_path):
     """
     def get_id_from_array(array):
         if len(set(array)) == 1:
-            return set(array)[0]
+            return array[0]
         else:
             return None
 


### PR DESCRIPTION
removes the casting to `set` of the array of `mc_particle` as set is not subscriptable 