### PR TITLE
Remove `ipympl` from setup.py dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'jupyter',
         'ipywidgets',
         'pyyaml',
-        'ipympl',
         'tqdm',
     ],
     tests_require=['pytest'],


### PR DESCRIPTION
I try to package `ctaplot` for Guix (it's one the last 3 missing packages to bring `magic-cta-pipe`); `ipympl` is not in use by any *.py files, but listed as install requirements.

`ipympl` was remove in Guix rectally, see https://codeberg.org/guix/guix/issues/5366.